### PR TITLE
Guzzle 7 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">= 7.3",
         "ext-json": "*",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "netresearch/jsonmapper": "^4.0"
     },
     "require-dev": {

--- a/src/connector/http/GuzzleRESTTemplate.php
+++ b/src/connector/http/GuzzleRESTTemplate.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace nl\rabobank\gict\payments_savings\omnikassa_sdk\connector\http;
 
 use GuzzleHttp\Client;
@@ -66,9 +65,13 @@ class GuzzleRESTTemplate implements RESTTemplate
                 'query' => $parameters,
             ]);
         } catch (ClientException $e) {
-            $response = $e->getResponse()->getBody()->getContents();
-            $message = sprintf('%s [body] %s', $e->getMessage(), $response);
-            throw new ClientException($message, $e->getRequest(), $e->getResponse());
+            $response = $e->getResponse();
+            if (null === $response) {
+                throw $e;
+            }
+            $responseBody = $response->getBody()->getContents();
+            $message = sprintf('%s [body] %s', $e->getMessage(), $responseBody);
+            throw new ClientException($message, $e->getRequest(), $response);
         }
 
         return $response->getBody()->getContents();
@@ -90,9 +93,13 @@ class GuzzleRESTTemplate implements RESTTemplate
                 'json' => $body,
             ]);
         } catch (ClientException $e) {
-            $response = $e->getResponse()->getBody()->getContents();
-            $message = sprintf('%s [body] %s', $e->getMessage(), $response);
-            throw new ClientException($message, $e->getRequest(), $e->getResponse());
+            $response = $e->getResponse();
+            if (null === $response) {
+                throw $e;
+            }
+            $responseBody = $response->getBody()->getContents();
+            $message = sprintf('%s [body] %s', $e->getMessage(), $responseBody);
+            throw new ClientException($message, $e->getRequest(), $response);
         }
 
         return $response->getBody()->getContents();


### PR DESCRIPTION
Add minor change to comply with the upgrade requirements by Guzzle (https://github.com/guzzle/guzzle/blob/7.5/UPGRADING.md) allowing both Guzzle 6 and 7 to be used as a valid dependency.