### PR TITLE
Fix jsonSerialize signatures to be compatible with PHP 8.1

### DIFF
--- a/src/model/AccessToken.php
+++ b/src/model/AccessToken.php
@@ -80,17 +80,7 @@ class AccessToken implements \JsonSerializable
         return $this->durationInMillis / 1000;
     }
 
-    /**
-     * Specify data which should be serialized to JSON.
-     *
-     * @see http://php.net/manual/en/jsonserializable.jsonserialize.php
-     *
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
-     *
-     * @since 5.4.0
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'token' => $this->token,

--- a/src/model/Address.php
+++ b/src/model/Address.php
@@ -141,10 +141,7 @@ class Address implements \JsonSerializable
         return $this->countryCode;
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $json = [];
         foreach ($this as $key => $value) {

--- a/src/model/CustomerInformation.php
+++ b/src/model/CustomerInformation.php
@@ -104,10 +104,7 @@ class CustomerInformation implements \JsonSerializable
         return $this->fullName;
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $json = [];
         foreach ($this as $key => $value) {

--- a/src/model/Money.php
+++ b/src/model/Money.php
@@ -80,10 +80,7 @@ class Money implements \JsonSerializable, SignatureDataProvider
         return [$this->currency, $this->amount];
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return ['currency' => $this->currency, 'amount' => $this->amount];
     }

--- a/src/model/OrderItem.php
+++ b/src/model/OrderItem.php
@@ -125,11 +125,7 @@ class OrderItem implements \JsonSerializable
         return $this->vatCategory;
     }
 
-    /**
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $json = [];
         foreach ($this as $key => $value) {

--- a/src/model/PaymentBrandMetaData.php
+++ b/src/model/PaymentBrandMetaData.php
@@ -35,11 +35,7 @@ final class PaymentBrandMetaData implements \JsonSerializable
         return !empty($this->properties);
     }
 
-    /**
-     * @return mixed data which can be serialized by <b>json_encode</b>,
-     *               which is a value of any type other than a resource
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $json = [];
         foreach ($this->properties as $key => $value) {

--- a/src/model/request/InitiateRefundRequest.php
+++ b/src/model/request/InitiateRefundRequest.php
@@ -46,8 +46,7 @@ class InitiateRefundRequest implements \JsonSerializable
         $this->vatCategory = $vatCategoryValue;
     }
 
-    /** {@inheritDoc} */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             'money' => $this->money,

--- a/src/model/request/MerchantOrder.php
+++ b/src/model/request/MerchantOrder.php
@@ -204,10 +204,7 @@ class MerchantOrder implements \JsonSerializable
         return $this->initiatingParty;
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $json = [];
         foreach ($this as $key => $value) {

--- a/src/model/request/MerchantOrderRequest.php
+++ b/src/model/request/MerchantOrderRequest.php
@@ -18,10 +18,7 @@ class MerchantOrderRequest implements \JsonSerializable
         $this->timestamp = new \DateTime('now');
     }
 
-    /**
-     * @return string
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $json['timestamp'] = $this->getFormattedTimestamp();
         foreach ($this->merchantOrder->jsonSerialize() as $key => $value) {

--- a/src/model/response/IdealIssuersInfo.php
+++ b/src/model/response/IdealIssuersInfo.php
@@ -46,10 +46,7 @@ class IdealIssuersInfo implements JsonSerializable
         }
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $json = [];
         foreach ($this as $key => $value) {

--- a/src/model/response/IdealIssuersLogo.php
+++ b/src/model/response/IdealIssuersLogo.php
@@ -32,10 +32,7 @@ class IdealIssuersLogo implements JsonSerializable
         }
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $json = [];
         foreach ($this as $key => $value) {

--- a/src/model/response/PaymentBrandInfo.php
+++ b/src/model/response/PaymentBrandInfo.php
@@ -68,10 +68,7 @@ class PaymentBrandInfo implements JsonSerializable
         $this->status = $status;
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $json = [];
         foreach ($this as $key => $value) {

--- a/src/model/response/PaymentBrandsResponse.php
+++ b/src/model/response/PaymentBrandsResponse.php
@@ -46,10 +46,7 @@ class PaymentBrandsResponse implements JsonSerializable
         return $this->paymentBrands;
     }
 
-    /**
-     * @return array
-     */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $json = [];
         foreach ($this as $key => $value) {


### PR DESCRIPTION
Since PHP 8.1 this package causes deprecation errors.

For example:

`
Deprecated: Return type of nl\rabobank\gict\payments_savings\omnikassa_sdk\model\Money::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
`

This commit solves these issues by adding the correct return type to all classes in this project that implement the `JsonSerializable` interface.
